### PR TITLE
WXT-4: UI dispatcher(wxCallAfter) 도입 – 백프레셔/메트릭 연동.

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -72,6 +72,8 @@ set(HEADERS
     include/planners/PlannerFactory.h
     include/render/RenderPipeline.h
     include/render/RenderMetricsExporter.h
+    include/ui/UiDispatcher.h
+    
 )
 
 # --- Render core library (shared by exe & tests) ---
@@ -111,12 +113,13 @@ if (BUILD_TESTING)
   endif()
 
   # Collect all test sources under test/*.cpp
-  file(GLOB TEST_SOURCES CONFIGURE_DEPENDS test/*.cpp)
+  file(GLOB TEST_SOURCES CONFIGURE_DEPENDS test/*.cpp test/ui/*.cpp)
 
   add_executable(unit_tests ${TEST_SOURCES})
   target_include_directories(unit_tests PRIVATE include)
   target_link_libraries(unit_tests
       PRIVATE
+          ${wxWidgets_LIBRARIES}
           GTest::gtest_main
           render_core
           nlohmann_json::nlohmann_json
@@ -124,6 +127,23 @@ if (BUILD_TESTING)
           $<IF:$<TARGET_EXISTS:fmt::fmt>,fmt::fmt,fmt::fmt-header-only>
   )
   target_compile_definitions(unit_tests PRIVATE FMT_HEADER_ONLY=1)
+
+  # Homebrew 경로를 명시적으로 추가
+  set(GTEST_ROOT "/opt/homebrew")
+  set(GTEST_INCLUDE_DIR "/opt/homebrew/include")
+  set(GTEST_LIB_DIR "/opt/homebrew/lib")
+
+  # GTest가 제대로 찾았는지 확인
+  if (NOT TARGET GTest::gtest_main)
+      add_library(GTest::gtest_main STATIC IMPORTED)
+      set_target_properties(GTest::gtest_main PROPERTIES
+          IMPORTED_LOCATION "${GTEST_LIB_DIR}/libgtest_main.a"
+          INTERFACE_INCLUDE_DIRECTORIES "${GTEST_INCLUDE_DIR}"
+      )
+  endif()
+
+  # 테스트 타겟에 include 경로 추가
+  target_include_directories(unit_tests PRIVATE ${GTEST_INCLUDE_DIR})
 
   include(GoogleTest)
   gtest_discover_tests(unit_tests)

--- a/app/include/ui/UiDispatcher.h
+++ b/app/include/ui/UiDispatcher.h
@@ -1,0 +1,99 @@
+#pragma
+#include <functional>
+#include <mutex>
+#include <atomic>
+#include <chrono>
+#include <string>
+
+// wx 의존은 "기본 poster"를 쓸 때만 필요하도록 분리
+// (단위 테스크에선 커스텀  poster 주입으로 wx 링크 없이도 테스크 가능)
+struct UiDispatcherConfig
+{
+    /* data */
+    size_t max_queue = 256;         // 큐 길이 상한
+    bool   enable_drop = true;      // 초과 시 드롭
+    bool   enable_coalesce = true;  // 동일 키 작업 합치기(옵션: 여기선 단순 드롭으로 시작)
+};
+
+class UiDispatcher {
+public:
+    // Poster : UI 스레드로 전달하는 함수 (기본은 wxCallAfter)
+    using Poster = std::function<void(std::function<void()>)>;
+    // MetricFn : 매트릭 기록 (key, value)
+    using MetricFn = std::function<void(const std::string&, double)>;
+
+    UiDispatcher(const UiDispatcherConfig& cfg, Poster poster, MetricFn metric = nullptr) 
+    : cfg_(cfg), poster_(std::move(poster)), metric_(std::move(metric)), pending_(0), drop_cnt_(0) {}
+
+    // UI 스레드로 콜백 전달. 성공 여부 반환.
+    bool post(std::function<void()> fn) {
+        // 백프레셔: 대기 수 체크
+        {
+            std::lock_guard<std::mutex> lk(mu_); // pending_ 증가
+            if (cfg_.enable_drop && pending_ >= cfg_.max_queue) {
+                ++drop_cnt_; // 드롭 카운트
+                record("ui_drop_cnt", static_cast<double>(drop_cnt_.load()));
+                record("ui_queue_len", static_cast<double>(pending_.load()));
+                return false;
+            }
+            ++pending_;
+            record("ui_queue_len", static_cast<double>(pending_.load()));
+        }
+
+        auto t0 = std::chrono::steady_clock::now();
+
+        // UI 스레드로 전달
+        poster_([this, t0, fn = std::move(fn)]() mutable {
+            fn();
+            auto t1 = std::chrono::steady_clock::now();
+            double latency_ms =
+                std::chrono::duration<double, std::milli>(t1 - t0).count();
+            record("ui_callback_latency_ms", latency_ms);
+
+            std::lock_guard<std::mutex> lk(mu_); // pending_ 감소
+            if (pending_ > 0) --pending_; // 안전장치
+            record("ui_queue_len", static_cast<double>(pending_.load()));
+        });
+
+        return true;
+    }
+
+    size_t pending() const { return pending_.load(); }
+    size_t drops() const { return drop_cnt_.load(); }
+    
+private:
+    void record(const std::string& key, double value) {
+        // 매트릭 기록 헬퍼
+        if (metric_) metric_(key, value);
+    }
+
+    UiDispatcherConfig cfg_;
+    Poster poster_;
+    MetricFn metric_;
+    mutable std::mutex mu_;
+    std::atomic<size_t> pending_;   // 대기 중 작업 수
+    std::atomic<size_t> drop_cnt_;  // 드롭된 작업 수
+    
+};
+
+// 기본 wxPoster (wxCallAfter 래퍼)
+#ifdef __has_include
+#    if __has_include(<wx/wx.h>)
+#        define WXT_HAVE_WX 1
+#    endif
+#endif
+
+#if WXT_HAVE_WX
+#include <wx/wx.h>
+static inline UiDispatcher::Poster MakeWxPoster() {
+    // // wxWidgets: UI 스레드로 보장되는 CallAfter
+    return [](std::function<void()> f) {
+        wxTheApp->CallAfter([fn = std::move(f)]() { fn(); });
+    };
+}
+#else
+static inline UiDispatcher::Poster MakeWxPoster() {
+    // wx 없음: 그냥 즉시 실행 (테스트용)
+    return [](std::function<void()> f){ f(); };
+}
+#endif

--- a/app/test/ui/UiDispatcherTest.cpp
+++ b/app/test/ui/UiDispatcherTest.cpp
@@ -54,6 +54,15 @@ TEST(UiDispatcherTest, MetricsLatencyRecorded) {
             if (key == "ui_callback_latency_ms") {
                 EXPECT_GE(value, 0.0);
             }
+            else if (key == "ui_queue_len") {
+                EXPECT_GE(value, 0.0);
+            }
+            else if (key == "ui_drop_cnt") {
+                EXPECT_GE(value, 0.0);
+            }
+            else {
+                FAIL() << "Unexpected metric key: " << key;
+            }
         });
 
     ASSERT_TRUE(d.post([]{}));

--- a/app/test/ui/UiDispatcherTest.cpp
+++ b/app/test/ui/UiDispatcherTest.cpp
@@ -1,0 +1,60 @@
+#include "ui/UiDispatcher.h"
+#include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+#include <thread>
+#include <iostream>
+
+TEST(UiDispatcherTest, BackpressureDropWhenQueueFull) {
+    // 동기 poster(바로 실행)로는 pending이 잘 안 쌓이므로
+    // 일부러 느리게 실행되는 poster를 만들어 대기열을 쌓이게 한다.
+    UiDispatcher::Poster slowPoster = [](std::function<void()> fn) {
+        std::thread([fn = std::move(fn)]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            fn();
+        }).detach();
+    };
+
+    std::atomic<size_t> metric_seen{0};
+    UiDispatcher::MetricFn metric = [&](const std::string&, double){
+        metric_seen++;
+    };
+
+    UiDispatcherConfig cfg;
+    cfg.enable_drop = true;
+    cfg.max_queue = 8; // 작게 설정
+
+    UiDispatcher dispatcher(cfg, slowPoster, metric);
+    size_t ok = 0, fail = 0;
+    std::vector<std::thread> ths;
+    for (int t = 0; t < 4; ++t) {
+        ths.emplace_back([&](){
+            for (int i = 0; i < 50; ++i) {
+                if (dispatcher.post([]{})) ++ok;
+                else ++fail;
+            }
+        });
+    }
+
+    for (auto& th : ths) th.join();
+
+    // 결과 값 출력 (디버그)
+    std::cout << "ok: " << ok << ", fail: " << fail << ", metric_seen: " << metric_seen.load() << std::endl;
+    // 큐 상한이 작으므로 drop이 발생했을 것이다.
+    EXPECT_GT(fail, 0);
+    EXPECT_EQ(ok, 200 - fail);
+    EXPECT_GE(metric_seen.load(), 1u);
+    std::cout << "ok: " << ok << ", fail: " << fail << std::endl;
+}
+
+TEST(UiDispatcherTest, MetricsLatencyRecorded) {
+    UiDispatcher::Poster testPoster = [](std::function<void()> fn) { fn(); };
+    UiDispatcher d(UiDispatcherConfig{}, testPoster,
+        [&](const std::string& key, double value){
+            if (key == "ui_callback_latency_ms") {
+                EXPECT_GE(value, 0.0);
+            }
+        });
+
+    ASSERT_TRUE(d.post([]{}));
+}


### PR DESCRIPTION
	•	큐 상한/드롭 정책 설명
	•	메트릭 키: ui_queue_len, ui_drop_cnt, ui_callback_latency_ms
	•	ctest -R UiDispatcherTest 로그 첨부