### PR TITLE
WXT-55: Add MapOverlayHUD with metrics, accessibility, and theming

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -72,6 +72,8 @@ set(HEADERS
     include/planners/PlannerFactory.h
     include/render/RenderPipeline.h
     include/render/RenderMetricsExporter.h
+    include/ui/UiDispatcher.h
+    
 )
 
 # --- Render core library (shared by exe & tests) ---
@@ -111,12 +113,13 @@ if (BUILD_TESTING)
   endif()
 
   # Collect all test sources under test/*.cpp
-  file(GLOB TEST_SOURCES CONFIGURE_DEPENDS test/*.cpp)
+  file(GLOB TEST_SOURCES CONFIGURE_DEPENDS test/*.cpp test/ui/*.cpp)
 
   add_executable(unit_tests ${TEST_SOURCES})
   target_include_directories(unit_tests PRIVATE include)
   target_link_libraries(unit_tests
       PRIVATE
+          ${wxWidgets_LIBRARIES}
           GTest::gtest_main
           render_core
           nlohmann_json::nlohmann_json
@@ -124,6 +127,23 @@ if (BUILD_TESTING)
           $<IF:$<TARGET_EXISTS:fmt::fmt>,fmt::fmt,fmt::fmt-header-only>
   )
   target_compile_definitions(unit_tests PRIVATE FMT_HEADER_ONLY=1)
+
+  # Homebrew 경로를 명시적으로 추가
+  set(GTEST_ROOT "/opt/homebrew")
+  set(GTEST_INCLUDE_DIR "/opt/homebrew/include")
+  set(GTEST_LIB_DIR "/opt/homebrew/lib")
+
+  # GTest가 제대로 찾았는지 확인
+  if (NOT TARGET GTest::gtest_main)
+      add_library(GTest::gtest_main STATIC IMPORTED)
+      set_target_properties(GTest::gtest_main PROPERTIES
+          IMPORTED_LOCATION "${GTEST_LIB_DIR}/libgtest_main.a"
+          INTERFACE_INCLUDE_DIRECTORIES "${GTEST_INCLUDE_DIR}"
+      )
+  endif()
+
+  # 테스트 타겟에 include 경로 추가
+  target_include_directories(unit_tests PRIVATE ${GTEST_INCLUDE_DIR})
 
   include(GoogleTest)
   gtest_discover_tests(unit_tests)

--- a/app/include/MapPanel.h
+++ b/app/include/MapPanel.h
@@ -2,9 +2,23 @@
 #include <wx/wx.h>
 #include <vector>
 #include "render/RenderPipeline.h"  // LonLat 타입 사용을 위해
+#include "ui/MapOverlayHud.h"
 
 class MapPanel : public wxPanel {
 public:
     explicit MapPanel(wxWindow* parent);
     void DrawPolyline(const std::vector<LonLat>& coords);
+
+    // HUD 바인딩 및 제어
+    void BindHudState(const ui::HudState& state) {
+        hud_->SetState(state); // 스레드 안전
+    }
+    void SetHudMetricHook(ui::MetricFn fn) {
+        hud_->SetMetricHook(std::move(fn));
+    }
+    void ToggleHudVisible() {
+        hud_->ToggleVisible();
+    }
+private:
+    ui::MapOverlayHud* hud_;
 };

--- a/app/include/ui/MapOverlayHud.h
+++ b/app/include/ui/MapOverlayHud.h
@@ -1,0 +1,68 @@
+#pragma once
+#include <wx/wx.h>
+#include <wx/dcbuffer.h>
+#include <functional>
+#include <string>
+#include <chrono>
+#include <mutex>
+
+namespace ui {
+
+enum class HudTheme { Day, Night, HighContrast };
+
+struct HudState {
+    bool visible = true;                       // HUD 표시/숨김
+    double speed_kmh = 0.0;                    // 현재 속도
+    double speed_limit_kmh = 0.0;              // 제한 속도
+    double distance_remain_m = 0.0;            // 남은 거리(m)
+    std::chrono::system_clock::time_point eta; // 도착 예상 시간
+    HudTheme theme = HudTheme::Day;            // 테마: 주간/야간/고대비
+    double font_scale = 1.0;                   // 접근성(크기 확장)
+};
+
+// 메트릭 훅: (key, value)
+using MetricFn = std::function<void(const std::string&, double)>;
+
+class MapOverlayHud : public wxPanel {
+public:
+    explicit MapOverlayHud(wxWindow* parent,
+                           wxWindowID id = wxID_ANY,
+                           const wxPoint& pos = wxDefaultPosition,
+                           const wxSize& size = wxDefaultSize);
+
+    void SetState(const HudState& s);          // 상태 바인딩(스레드 안전)
+    void ToggleVisible();                      // 표시/숨김 토글
+    void SetMetricHook(MetricFn fn);           // 메트릭 콜백 주입
+
+    static void DrawHudStatic(wxDC& dc, const HudState& state, int dpi_scale);
+
+protected:
+    void OnPaint(wxPaintEvent& e);
+    void OnSize(wxSizeEvent& e);
+
+private:
+    // 렌더 보조
+    void DrawHud(wxBufferedPaintDC& dc);
+    void ResolveTheme(wxColour& fg, wxColour& fgSecondary, wxColour& bg, wxColour& accent) const;
+    int  Px(double logicalPx) const;           // HiDPI 스케일 적용
+    wxString FormatSpeed(double kmh) const;
+    wxString FormatSpeedLimit(double kmh) const;
+    wxString FormatDistance(double m) const;
+    wxString FormatETA(std::chrono::system_clock::time_point eta) const;
+
+private:
+    mutable std::mutex mtx_;
+    HudState state_;
+    MetricFn metric_;
+
+    // 페인트 메트릭
+    std::chrono::steady_clock::time_point last_paint_start_{};
+    bool first_paint_done_{false};
+
+    // 레이아웃 캐시
+    int dpi_scale_ = 1;
+
+    wxDECLARE_EVENT_TABLE();
+};
+
+} // namespace ui

--- a/app/include/ui/UiDispatcher.h
+++ b/app/include/ui/UiDispatcher.h
@@ -1,0 +1,99 @@
+#pragma
+#include <functional>
+#include <mutex>
+#include <atomic>
+#include <chrono>
+#include <string>
+
+// wx 의존은 "기본 poster"를 쓸 때만 필요하도록 분리
+// (단위 테스크에선 커스텀  poster 주입으로 wx 링크 없이도 테스크 가능)
+struct UiDispatcherConfig
+{
+    /* data */
+    size_t max_queue = 256;         // 큐 길이 상한
+    bool   enable_drop = true;      // 초과 시 드롭
+    bool   enable_coalesce = true;  // 동일 키 작업 합치기(옵션: 여기선 단순 드롭으로 시작)
+};
+
+class UiDispatcher {
+public:
+    // Poster : UI 스레드로 전달하는 함수 (기본은 wxCallAfter)
+    using Poster = std::function<void(std::function<void()>)>;
+    // MetricFn : 매트릭 기록 (key, value)
+    using MetricFn = std::function<void(const std::string&, double)>;
+
+    UiDispatcher(const UiDispatcherConfig& cfg, Poster poster, MetricFn metric = nullptr) 
+    : cfg_(cfg), poster_(std::move(poster)), metric_(std::move(metric)), pending_(0), drop_cnt_(0) {}
+
+    // UI 스레드로 콜백 전달. 성공 여부 반환.
+    bool post(std::function<void()> fn) {
+        // 백프레셔: 대기 수 체크
+        {
+            std::lock_guard<std::mutex> lk(mu_); // pending_ 증가
+            if (cfg_.enable_drop && pending_ >= cfg_.max_queue) {
+                ++drop_cnt_; // 드롭 카운트
+                record("ui_drop_cnt", static_cast<double>(drop_cnt_.load()));
+                record("ui_queue_len", static_cast<double>(pending_.load()));
+                return false;
+            }
+            ++pending_;
+            record("ui_queue_len", static_cast<double>(pending_.load()));
+        }
+
+        auto t0 = std::chrono::steady_clock::now();
+
+        // UI 스레드로 전달
+        poster_([this, t0, fn = std::move(fn)]() mutable {
+            fn();
+            auto t1 = std::chrono::steady_clock::now();
+            double latency_ms =
+                std::chrono::duration<double, std::milli>(t1 - t0).count();
+            record("ui_callback_latency_ms", latency_ms);
+
+            std::lock_guard<std::mutex> lk(mu_); // pending_ 감소
+            if (pending_ > 0) --pending_; // 안전장치
+            record("ui_queue_len", static_cast<double>(pending_.load()));
+        });
+
+        return true;
+    }
+
+    size_t pending() const { return pending_.load(); }
+    size_t drops() const { return drop_cnt_.load(); }
+    
+private:
+    void record(const std::string& key, double value) {
+        // 매트릭 기록 헬퍼
+        if (metric_) metric_(key, value);
+    }
+
+    UiDispatcherConfig cfg_;
+    Poster poster_;
+    MetricFn metric_;
+    mutable std::mutex mu_;
+    std::atomic<size_t> pending_;   // 대기 중 작업 수
+    std::atomic<size_t> drop_cnt_;  // 드롭된 작업 수
+    
+};
+
+// 기본 wxPoster (wxCallAfter 래퍼)
+#ifdef __has_include
+#    if __has_include(<wx/wx.h>)
+#        define WXT_HAVE_WX 1
+#    endif
+#endif
+
+#if WXT_HAVE_WX
+#include <wx/wx.h>
+static inline UiDispatcher::Poster MakeWxPoster() {
+    // // wxWidgets: UI 스레드로 보장되는 CallAfter
+    return [](std::function<void()> f) {
+        wxTheApp->CallAfter([fn = std::move(f)]() { fn(); });
+    };
+}
+#else
+static inline UiDispatcher::Poster MakeWxPoster() {
+    // wx 없음: 그냥 즉시 실행 (테스트용)
+    return [](std::function<void()> f){ f(); };
+}
+#endif

--- a/app/src/MapPanel.cpp
+++ b/app/src/MapPanel.cpp
@@ -10,6 +10,8 @@ inline void to_json(nlohmann::json& j, const LonLat& p) {
 
 MapPanel::MapPanel(wxWindow* parent) : wxPanel(parent, wxID_ANY) {
     // WebView 초기화 코드 (생략)
+    hud_ = new ui::MapOverlayHud(this);
+    // ...existing code...
 }
 
 void MapPanel::DrawPolyline(const std::vector<LonLat>& coords) {
@@ -24,3 +26,4 @@ void MapPanel::DrawPolyline(const std::vector<LonLat>& coords) {
         spdlog::info("[ACK] JS drawPolyline called with {} points", count);
     });
 }
+

--- a/app/src/ui/MapOverlayHud.cpp
+++ b/app/src/ui/MapOverlayHud.cpp
@@ -1,0 +1,278 @@
+#include "ui/MapOverlayHud.h"
+#include <wx/datetime.h>
+#include <iomanip>
+#include <sstream>
+
+
+namespace ui {
+
+wxBEGIN_EVENT_TABLE(MapOverlayHud, wxPanel)
+    EVT_PAINT(MapOverlayHud::OnPaint)
+    EVT_SIZE(MapOverlayHud::OnSize)
+wxEND_EVENT_TABLE()
+
+MapOverlayHud::MapOverlayHud(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size)
+    : wxPanel(parent, id, pos, size)
+{
+    SetBackgroundStyle(wxBG_STYLE_PAINT); // 더블버퍼 페인트
+#if defined(__WXMAC__)
+    dpi_scale_ = std::max(1, int(std::round(GetContentScaleFactor())));
+#else
+    dpi_scale_ = 1;
+#endif
+}
+
+void MapOverlayHud::SetState(const HudState& s) {
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        state_ = s;
+    }
+    Refresh(); // 다시 그리기
+}
+
+void MapOverlayHud::ToggleVisible() {
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        state_.visible = !state_.visible;
+    }
+    if (metric_) metric_("hud_visible", state_.visible ? 1.0 : 0.0);
+    Refresh();
+}
+
+void MapOverlayHud::SetMetricHook(MetricFn fn) {
+    std::lock_guard<std::mutex> lk(mtx_);
+    metric_ = std::move(fn);
+}
+
+void MapOverlayHud::DrawHudStatic(wxDC& dc, const HudState& state, int dpi_scale) {
+    wxColour fg, fg2, bg, accent;
+    switch (state.theme) {
+        case HudTheme::Day:
+            bg = wxColour(255,255,255,230);
+            fg = *wxBLACK;
+            fg2 = wxColour(70,70,70);
+            accent = wxColour(0,122,255);
+            break;
+        case HudTheme::Night:
+            bg = wxColour(20,20,20,200);
+            fg = *wxWHITE;
+            fg2 = wxColour(180,180,180);
+            accent = wxColour(10,132,255);
+            break;
+        case HudTheme::HighContrast:
+            bg = wxColour(0,0,0,230);
+            fg = *wxWHITE;
+            fg2 = wxColour(220,220,0);
+            accent = wxColour(255,215,0);
+            break;
+    }
+
+    // 배경
+    wxSize sz = dc.GetSize();
+    dc.SetPen(*wxTRANSPARENT_PEN);
+    dc.SetBrush(wxBrush(bg));
+    dc.DrawRectangle({0,0}, sz);
+
+    if (!state.visible) {
+        // 숨김 상태면 아무것도 그리지 않음
+        return;
+    }
+
+    // HiDPI 및 접근성 스케일 적용
+    auto Px = [&](double logicalPx) {
+        return int(std::round(logicalPx * dpi_scale * std::max(0.75, state.font_scale)));
+    };
+
+    // 텍스트(큰 정보와 보조 정보 계층화)
+    wxFont big(Px(32), wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD);
+    wxFont small(Px(16), wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+
+    dc.SetTextForeground(fg);
+
+    // 속도/제한속도
+    int speed_v = int(std::round(state.speed_kmh));
+    wxString speed = wxString::Format("%d km/h", speed_v);
+
+    wxString limit = (state.speed_limit_kmh <= 0.0)
+        ? "—"
+        : wxString::Format("제한 %d", int(std::round(state.speed_limit_kmh)));
+
+    dc.SetFont(big);
+    dc.DrawText(speed, Px(16), Px(12));
+
+    dc.SetFont(small);
+    dc.SetTextForeground(fg2);
+    dc.DrawText(limit, Px(16), Px(52));
+
+    // 하단: ETA / 남은 거리
+    dc.SetTextForeground(fg);
+    dc.SetFont(small);
+
+    wxString etaStr;
+    if (state.eta.time_since_epoch().count() == 0) {
+        etaStr = "ETA —";
+    } else {
+        std::time_t t = std::chrono::system_clock::to_time_t(state.eta);
+        wxDateTime dt((time_t)t);
+        etaStr = wxString::Format("ETA %s", dt.FormatISOTime());
+    }
+
+    wxString distStr;
+    if (state.distance_remain_m >= 1000.0) {
+        double km = state.distance_remain_m / 1000.0;
+        distStr = wxString::Format("%.1f km", km);
+    } else {
+        distStr = wxString::Format("%d m", int(std::round(state.distance_remain_m)));
+    }
+
+    auto eta_size  = dc.GetTextExtent(etaStr);
+    auto dist_size = dc.GetTextExtent(distStr);
+
+    int padding = Px(12);
+    int rightX_eta  = sz.x - eta_size.x - padding;
+    int rightX_dist = sz.x - dist_size.x - padding;
+
+    dc.DrawText(etaStr,  rightX_eta,  sz.y - eta_size.y  - padding);
+    dc.DrawText(distStr, rightX_dist, sz.y - dist_size.y - padding - eta_size.y - Px(8));
+
+    // 속도 강조용 얇은 밑줄(액센트)
+    dc.SetPen(wxPen(accent, Px(2)));
+    int speed_w, speed_h;
+    dc.GetTextExtent(speed, &speed_w, &speed_h);
+    dc.DrawLine(Px(16), Px(12 + 32 + 6), Px(16 + speed_w), Px(12 + 32 + 6));
+}
+
+void MapOverlayHud::OnSize(wxSizeEvent& e) {
+    Refresh();
+    e.Skip();
+}
+
+int MapOverlayHud::Px(double logicalPx) const {
+    return int(std::round(logicalPx * dpi_scale_ * std::max(0.75, state_.font_scale)));
+}
+
+wxString MapOverlayHud::FormatSpeed(double kmh) const {
+    int v = int(std::round(kmh));
+    return wxString::Format("%d km/h", v);
+}
+
+wxString MapOverlayHud::FormatSpeedLimit(double kmh) const {
+    if (kmh <= 0.0) return "—";
+    int v = int(std::round(kmh));
+    return wxString::Format("제한 %d", v);
+}
+
+wxString MapOverlayHud::FormatDistance(double m) const {
+    if (m >= 1000.0) {
+        double km = m / 1000.0;
+        return wxString::Format("%.1f km", km);
+    }
+    return wxString::Format("%d m", int(std::round(m)));
+}
+
+wxString MapOverlayHud::FormatETA(std::chrono::system_clock::time_point eta) const {
+    if (eta.time_since_epoch().count() == 0) return "ETA —";
+    std::time_t t = std::chrono::system_clock::to_time_t(eta);
+    wxDateTime dt((time_t)t);
+    return wxString::Format("ETA %s", dt.FormatISOTime());
+}
+
+void MapOverlayHud::ResolveTheme(wxColour& fg, wxColour& fgSecondary, wxColour& bg, wxColour& accent) const {
+    switch (state_.theme) {
+        case HudTheme::Day:
+            bg = wxColour(255,255,255,230);
+            fg = *wxBLACK;
+            fgSecondary = wxColour(70,70,70);
+            accent = wxColour(0,122,255);
+            break;
+        case HudTheme::Night:
+            bg = wxColour(20,20,20,200);
+            fg = *wxWHITE;
+            fgSecondary = wxColour(180,180,180);
+            accent = wxColour(10,132,255);
+            break;
+        case HudTheme::HighContrast:
+            bg = wxColour(0,0,0,230);
+            fg = *wxWHITE;
+            fgSecondary = wxColour(220,220,0);
+            accent = wxColour(255,215,0);
+            break;
+    }
+}
+
+void MapOverlayHud::OnPaint(wxPaintEvent& e) {
+    auto paint_start = std::chrono::steady_clock::now();
+    wxAutoBufferedPaintDC auto_dc(this);
+    wxBufferedPaintDC dc(this);
+
+    HudState s;
+    MetricFn mh;
+    {
+        std::lock_guard<std::mutex> lk(mtx_);
+        s = state_;
+        mh = metric_;
+    }
+
+    wxColour fg, fg2, bg, accent;
+    ResolveTheme(fg, fg2, bg, accent);
+
+    wxSize sz = GetClientSize();
+    dc.SetPen(*wxTRANSPARENT_PEN);
+    dc.SetBrush(wxBrush(bg));
+    dc.DrawRectangle({0,0}, sz);
+
+    if (!s.visible) {
+        if (mh) mh("hud_visible", 0.0);
+        if (mh) {
+            auto ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - paint_start).count();
+            mh("hud_paint_ms", ms);
+        }
+        return;
+    }
+
+    wxFont big(Px(32), wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD);
+    wxFont small(Px(16), wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+
+    dc.SetTextForeground(fg);
+
+    wxString speed = FormatSpeed(s.speed_kmh);
+    wxString limit = FormatSpeedLimit(s.speed_limit_kmh);
+
+    dc.SetFont(big);
+    dc.DrawText(speed, Px(16), Px(12));
+
+    dc.SetFont(small);
+    dc.SetTextForeground(fg2);
+    dc.DrawText(limit, Px(16), Px(52));
+
+    dc.SetTextForeground(fg);
+    dc.SetFont(small);
+
+    wxString etaStr = FormatETA(s.eta);
+    wxString distStr = FormatDistance(s.distance_remain_m);
+
+    auto eta_size  = dc.GetTextExtent(etaStr);
+    auto dist_size = dc.GetTextExtent(distStr);
+
+    int padding = Px(12);
+    int rightX_eta  = sz.x - eta_size.x - padding;
+    int rightX_dist = sz.x - dist_size.x - padding;
+
+    dc.DrawText(etaStr,  rightX_eta,  sz.y - eta_size.y  - padding);
+    dc.DrawText(distStr, rightX_dist, sz.y - dist_size.y - padding - eta_size.y - Px(8));
+
+    dc.SetPen(wxPen(accent, Px(2)));
+    int speed_w, speed_h;
+    dc.GetTextExtent(speed, &speed_w, &speed_h);
+    dc.DrawLine(Px(16), Px(12 + 32 + 6), Px(16 + speed_w), Px(12 + 32 + 6));
+
+    if (mh) mh("hud_visible", 1.0);
+    if (mh) {
+        auto ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - paint_start).count();
+        mh("hud_paint_ms", ms);
+    }
+
+    if (!first_paint_done_) first_paint_done_ = true;
+}
+
+} // namespace ui

--- a/app/test/ui/MapOverlayHudTest.cpp
+++ b/app/test/ui/MapOverlayHudTest.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+#include "ui/MapOverlayHud.h"
+#include <wx/dcmemory.h>
+#include <wx/bitmap.h>
+#include <chrono>
+
+TEST(MapOverlayHudTest, FirstPaintUnder2s) {
+    ui::HudState state;
+    wxBitmap bmp(800, 600);
+    wxMemoryDC memDC(bmp);
+    wxBufferedDC dc(&memDC, bmp); // 버그 수정: wxBufferedPaintDC 대신 wxBufferedDC 사용
+    auto t0 = std::chrono::steady_clock::now();
+    ui::MapOverlayHud::DrawHudStatic(dc, state, 1);
+    auto t1 = std::chrono::steady_clock::now();
+
+    double elapsed = std::chrono::duration<double>(t1 - t0).count();
+    EXPECT_LT(elapsed, 2.0); // 2초 이내에 그려져야 함
+}

--- a/app/test/ui/UiDispatcherTest.cpp
+++ b/app/test/ui/UiDispatcherTest.cpp
@@ -54,6 +54,15 @@ TEST(UiDispatcherTest, MetricsLatencyRecorded) {
             if (key == "ui_callback_latency_ms") {
                 EXPECT_GE(value, 0.0);
             }
+            else if (key == "ui_queue_len") {
+                EXPECT_GE(value, 0.0);
+            }
+            else if (key == "ui_drop_cnt") {
+                EXPECT_GE(value, 0.0);
+            }
+            else {
+                FAIL() << "Unexpected metric key: " << key;
+            }
         });
 
     ASSERT_TRUE(d.post([]{}));

--- a/app/test/ui/UiDispatcherTest.cpp
+++ b/app/test/ui/UiDispatcherTest.cpp
@@ -1,0 +1,60 @@
+#include "ui/UiDispatcher.h"
+#include <gtest/gtest.h>
+#include <atomic>
+#include <thread>
+#include <thread>
+#include <iostream>
+
+TEST(UiDispatcherTest, BackpressureDropWhenQueueFull) {
+    // 동기 poster(바로 실행)로는 pending이 잘 안 쌓이므로
+    // 일부러 느리게 실행되는 poster를 만들어 대기열을 쌓이게 한다.
+    UiDispatcher::Poster slowPoster = [](std::function<void()> fn) {
+        std::thread([fn = std::move(fn)]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+            fn();
+        }).detach();
+    };
+
+    std::atomic<size_t> metric_seen{0};
+    UiDispatcher::MetricFn metric = [&](const std::string&, double){
+        metric_seen++;
+    };
+
+    UiDispatcherConfig cfg;
+    cfg.enable_drop = true;
+    cfg.max_queue = 8; // 작게 설정
+
+    UiDispatcher dispatcher(cfg, slowPoster, metric);
+    size_t ok = 0, fail = 0;
+    std::vector<std::thread> ths;
+    for (int t = 0; t < 4; ++t) {
+        ths.emplace_back([&](){
+            for (int i = 0; i < 50; ++i) {
+                if (dispatcher.post([]{})) ++ok;
+                else ++fail;
+            }
+        });
+    }
+
+    for (auto& th : ths) th.join();
+
+    // 결과 값 출력 (디버그)
+    std::cout << "ok: " << ok << ", fail: " << fail << ", metric_seen: " << metric_seen.load() << std::endl;
+    // 큐 상한이 작으므로 drop이 발생했을 것이다.
+    EXPECT_GT(fail, 0);
+    EXPECT_EQ(ok, 200 - fail);
+    EXPECT_GE(metric_seen.load(), 1u);
+    std::cout << "ok: " << ok << ", fail: " << fail << std::endl;
+}
+
+TEST(UiDispatcherTest, MetricsLatencyRecorded) {
+    UiDispatcher::Poster testPoster = [](std::function<void()> fn) { fn(); };
+    UiDispatcher d(UiDispatcherConfig{}, testPoster,
+        [&](const std::string& key, double value){
+            if (key == "ui_callback_latency_ms") {
+                EXPECT_GE(value, 0.0);
+            }
+        });
+
+    ASSERT_TRUE(d.post([]{}));
+}


### PR DESCRIPTION
- MapOverlayHUD 클래스를 도입하여 속도/제한속도/거리/ETA를 HUD 위젯으로 표시.
- 더블 버퍼링, HiDPI/접근성 지원, 주간/야간/고대비 테마 반영.
- 메트릭(csv): hud_paint_ms, hud_visible 기록.